### PR TITLE
Changes to README - add left out details from entity object properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ callbacks gives you the extracted data from LDtk project file.
 | -- | -- | -- |
 | x | x position | integer |
 | y | y position | integer |
+| identifier | the entity name | string |
 | width | the entity width in pixels | integer |
 | height | the entity height in pixels | integer |
 | visisble | whether the entity is visible or not | boolean |


### PR DESCRIPTION
The entity identifier property seems to have been left out from the properties table, and yet its quite crucial non the less