### PR TITLE
Parse __neighbours and pass level to callbacks

### DIFF
--- a/ldtk.lua
+++ b/ldtk.lua
@@ -277,7 +277,7 @@ end
 
 
 local types = {
-    Entities = function (currentLayer, order)
+    Entities = function (currentLayer, order, level)
         for _, value in ipairs(currentLayer.entityInstances) do
             local props = {}
 
@@ -296,34 +296,34 @@ local types = {
                 order = order,
                 visible = currentLayer.visible,
                 props = props
-            })
+            }, level)
         end
     end,
 
-    Tiles = function (currentLayer, order)
+    Tiles = function (currentLayer, order, level)
         if not is_empty(currentLayer.gridTiles) then
             local layer = {draw = draw_layer_object}
             create_layer_object(layer, currentLayer, false)
             layer.order = order
-            ldtk.onLayer(layer)
+            ldtk.onLayer(layer, level)
         end
     end,
 
-    IntGrid = function (currentLayer, order)
+    IntGrid = function (currentLayer, order, level)
         if not is_empty(currentLayer.autoLayerTiles) and currentLayer.__tilesetDefUid then
             local layer = {draw = draw_layer_object}
             create_layer_object(layer, currentLayer, true)
             layer.order = order
-            ldtk.onLayer(layer)
+            ldtk.onLayer(layer, level)
         end
     end,
 
-    AutoLayer = function (currentLayer, order)
+    AutoLayer = function (currentLayer, order, level)
         if not is_empty(currentLayer.autoLayerTiles) and currentLayer.__tilesetDefUid then
             local layer = {draw = draw_layer_object}
             create_layer_object(layer, currentLayer, true)
             layer.order = order
-            ldtk.onLayer(layer)
+            ldtk.onLayer(layer, level)
         end
     end
 }
@@ -359,6 +359,7 @@ function ldtk:goTo(index)
         worldY = self.data.levels[index].worldY,
         width = self.data.levels[index].pxWid,
         height = self.data.levels[index].pxHei,
+        neighbours = self.data.levels[index].__neighbours,
         index = index,
         props = levelProps
     }
@@ -473,7 +474,7 @@ end
     Remember that colors are saved in HEX format and not RGB. 
     You can use ldtk ldtk.hex2rgb(color) to get an RGB table like {0.21, 0.57, 0.92}
 ]]
-function ldtk.onEntity(entity)
+function ldtk.onEntity(entity, level)
     
 end
 
@@ -492,7 +493,7 @@ end
         draw        = (function) -- used to draw the layer
     }
 ]]
-function ldtk.onLayer(layer)
+function ldtk.onLayer(layer, level)
     
 end
 


### PR DESCRIPTION
Parsing neighbours enables more advanced usage patterns, i.e. keeping the current level and neighbours loaded as you move through the world.

Passing level to the callbacks allows you to optionally offset, entities/layers based on the level's position in the world rather than everything being relative to the origin as it currently is.