### PR TITLE
add unique iid identifier to entity objects

### DIFF
--- a/ldtk.lua
+++ b/ldtk.lua
@@ -290,6 +290,7 @@ local types = {
 
             ldtk.onEntity({
                 id = value.__identifier,
+                iid = value.iid,
                 x = value.px[1],
                 y = value.px[2],
                 width = value.width,


### PR DESCRIPTION
This PR add the unique identifier `iid` field to entity objects.
https://ldtk.io/docs/game-dev/json-overview/unique-identifiers/

This is useful to have handy when you want to keep track of instances of entities. For example you could keep a table of entities that have died, or have been removed from a level, and ignore adding them the next time `ldtk.onEntity` is called.

Let me know your thoughts on this or if there is already a technique for handling this sort of situation! 