### PR TITLE
Fixed edge case issue when cross-compiling to JavaScript for web deployment

### DIFF
--- a/ldtk.lua
+++ b/ldtk.lua
@@ -214,9 +214,7 @@ end
 ----------- LDTK Functions -------------
 --loads project settings
 function ldtk:load(file, level)
-    if love.filesystem.getInfo(file) then
-        print("[löve-LDtk] Loading file:", file)
-    end
+    print("[löve-LDtk] Loading file:", file)
     local content, size = love.filesystem.read(file)
     if not content then
         error("[löve-LDtk] Failed to read file: " .. file)


### PR DESCRIPTION
I'm learning Lua for a game-jam in place of C++ and I wanted to compile for the web because of the ease of access. This LDtk-loader works like a charm but when using this nifty tool that handles emscripten things (https://schellingb.github.io/LoveWebBuilder/run-project) I got the attached error. I've replaced the load() function with a tonumber() function to simplify the conversion function and now no errors in loading on either desktop or web.